### PR TITLE
Shipping, returns, domestic-only, order-status, test product scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,10 @@ VITE_ENABLE_WISHLIST=true
 VITE_ENABLE_ORDER_TRACKING=true
 VITE_ENABLE_MAINTENANCE_PAGE=false
 VITE_CHECKOUT_MODE=both
+# Shipping: fixed fee in USD when delivery is selected (default 10). Material & media shipping. Domestic (US) only.
+# VITE_SHIPPING_FEE=10
+# Free shipping when order subtotal >= this (USD). 0 = no free shipping. Backend: FREE_SHIPPING_THRESHOLD_CENTS (cents).
+# VITE_FREE_SHIPPING_THRESHOLD=0
 
 # ============================================
 # MAKE.COM WEBHOOKS
@@ -87,6 +91,10 @@ SQUARE_LOCATION_ID=your-square-location-id
 
 # Optional: protect admin webhooks (used by /api/square/sync, /api/orders/update, etc.)
 WEBHOOK_SECRET=your-shared-secret
+
+# Shipping (server): /api/pay calculates shipping. Material & media. Domestic (US) only. SHIPPING_FEE (USD) or SHIPPING_FEE_CENTS. Optional: FREE_SHIPPING_THRESHOLD_CENTS.
+# SHIPPING_FEE=10
+# FREE_SHIPPING_THRESHOLD_CENTS=0
 
 # ============================================
 # REVIEWS

--- a/api/emailTemplates.js
+++ b/api/emailTemplates.js
@@ -331,10 +331,14 @@ export function generateOrderConfirmationEmail(data) {
     items = [],
     deliveryMethod,
     pickupLocation,
+    shippingAddress,
   } = data
-  
+
   const currencySymbol = currency === 'USD' ? '$' : ''
   const formattedTotal = `${currencySymbol}${parseFloat(total).toFixed(2)}`
+  const pickupLine = deliveryMethod === 'pickup'
+    ? escapeHtml(pickupLocation || '215B Main Street, Milford, OH 45150')
+    : (shippingAddress ? escapeHtml(shippingAddress) : 'Your order will be shipped to the address provided during checkout.')
   
   const itemsHtml = items.map(item => {
     const itemPrice = typeof item.price === 'number' ? item.price.toFixed(2) : (item.price || '0.00')
@@ -354,9 +358,6 @@ export function generateOrderConfirmationEmail(data) {
   const baseUrl = getBaseUrl()
   const safeCustomerName = escapeHtml(customerName || 'Valued Customer')
   const safeOrderNumber = escapeHtml(orderNumber || '')
-  const pickupLine = deliveryMethod === 'pickup'
-    ? escapeHtml(pickupLocation || '215B Main Street, Milford, OH 45150')
-    : 'Your order will be shipped to the address provided during checkout.'
 
   const bodyHtml = `
     <div style="text-align:center; margin-bottom: 18px;">

--- a/api/orders.js
+++ b/api/orders.js
@@ -57,6 +57,7 @@ export async function webHandler(request) {
         o.total_cents,
         o.status,
         o.pickup_details,
+        o.delivery_method,
         o.created_at,
         o.updated_at
       FROM orders o
@@ -84,16 +85,25 @@ export async function webHandler(request) {
     const result = await query(sql, params)
 
     // Normalize response: ensure pickup_details + items are consistently shaped.
+    // Use delivery_method column as fallback when pickup_details.deliveryMethod is missing (e.g. before migration).
     const orders = (result.rows || []).map((row) => {
       const pickup = row.pickup_details && typeof row.pickup_details === 'string'
         ? (() => { try { return JSON.parse(row.pickup_details) } catch { return {} } })()
         : (row.pickup_details || {})
 
       const items = Array.isArray(pickup?.items) ? pickup.items : []
+      // Support camelCase (from frontend) and snake_case (from some DB/JSON)
+      const fromPickup = pickup?.deliveryMethod ?? pickup?.delivery_method
+      const fromRow = row.delivery_method
+      const hasShippingAddress = !!(pickup?.address && (pickup?.city || pickup?.zipCode))
+      let deliveryMethod = fromPickup || fromRow
+      if (!deliveryMethod && hasShippingAddress) deliveryMethod = 'delivery'
+      if (!deliveryMethod) deliveryMethod = 'pickup'
 
       return {
         ...row,
-        pickup_details: pickup,
+        pickup_details: { ...pickup, deliveryMethod },
+        delivery_method: deliveryMethod,
         items,
         customer_email: pickup?.email || null,
         customer_phone: pickup?.phone || null,

--- a/api/orders/update.js
+++ b/api/orders/update.js
@@ -51,7 +51,7 @@ export async function webHandler(request) {
     }
 
     const body = await request.json()
-    const { order_id, status, forceEmail } = body
+    const { order_id, status, forceEmail, trackingNumber, trackingUrl } = body
 
     if (!order_id) {
       return new Response(
@@ -125,11 +125,17 @@ export async function webHandler(request) {
     const wasComplete = prevUpper === 'COMPLETED' || prevUpper === 'PICKED_UP' || prevUpper === 'DELIVERED'
     const isComplete = nextUpper === 'COMPLETED' || nextUpper === 'PICKED_UP' || nextUpper === 'DELIVERED'
 
-    // Update the order status and fetch the updated row in one round-trip.
+    // Merge optional tracking into pickup_details (for delivery orders; shown on track-order page).
+    const mergedPickup =
+      trackingNumber != null || trackingUrl != null
+        ? { ...pickupDetails, ...(trackingNumber != null && { trackingNumber: String(trackingNumber) }), ...(trackingUrl != null && { trackingUrl: String(trackingUrl) }) }
+        : pickupDetails
+
+    // Update the order status (and pickup_details when tracking provided) and fetch the updated row.
     const updatedOrder = await query(
       `UPDATE orders
-       SET status = $1, updated_at = CURRENT_TIMESTAMP
-       WHERE id = $2
+       SET status = $1, pickup_details = $2::jsonb, updated_at = CURRENT_TIMESTAMP
+       WHERE id = $3
        RETURNING
          id,
          order_number,
@@ -138,7 +144,7 @@ export async function webHandler(request) {
          total_cents,
          updated_at,
          pickup_details`,
-      [status, dbOrderId],
+      [status, JSON.stringify(mergedPickup), dbOrderId],
     )
 
     const updatedPickup =

--- a/api/pay.js
+++ b/api/pay.js
@@ -209,7 +209,8 @@ export async function webHandler(request) {
     }
 
     // Validate required fields
-    const { sourceId, idempotencyKey, cartItems, pickupForm } = requestBody
+    const { sourceId, idempotencyKey, cartItems, pickupForm, shippingCents: requestShippingCents } = requestBody
+    const deliveryMethod = pickupForm?.deliveryMethod || 'pickup'
 
     if (!sourceId) {
       const { sendSlackAlert } = await import('./slackAlerts.js')
@@ -325,6 +326,18 @@ export async function webHandler(request) {
         squareVariationId: variationId || null,
       }
     })
+
+    // Calculate shipping server-side (source of truth). Pickup = 0. Delivery = fixed fee unless order meets free-shipping threshold.
+    const subtotalCents = canonicalCartItems.reduce((sum, it) => sum + it.priceCents * it.quantity, 0)
+    const feeCents = Number(process.env.SHIPPING_FEE_CENTS)
+    const feeDollars = Number(process.env.SHIPPING_FEE || 10)
+    const rawFee = Number.isFinite(feeCents) ? feeCents : feeDollars * 100
+    const fixedShippingCents = Math.max(0, Math.round(rawFee))
+    const freeShippingThresholdCents = Math.max(0, Math.round(Number(process.env.FREE_SHIPPING_THRESHOLD_CENTS || 0)))
+    const shippingCents =
+      deliveryMethod === 'delivery'
+        ? (freeShippingThresholdCents > 0 && subtotalCents >= freeShippingThresholdCents ? 0 : fixedShippingCents)
+        : 0
 
     // 0. Handle Customer FIRST (before creating order, so we can link it)
     const email = pickupForm?.email || ''
@@ -483,7 +496,9 @@ export async function webHandler(request) {
     let squareOrderForTotals = null
     
     try {
-      // Construct canonical Square line items using server-side prices + variation IDs
+      // Construct canonical Square line items. In sandbox, use name+price only (no catalogObjectId) so
+      // test/manually-added products that exist in our DB but not in Square's sandbox catalog still work.
+      const useCatalogIds = squareEnv !== 'sandbox'
       const lineItems = canonicalCartItems.map((item) => {
         const lineItem = {
           quantity: String(item.quantity),
@@ -492,15 +507,25 @@ export async function webHandler(request) {
             currency: 'USD',
           },
         }
-
-        if (item.squareVariationId) {
+        if (useCatalogIds && item.squareVariationId) {
           lineItem.catalogObjectId = item.squareVariationId
         } else {
-          // Fallback (should be rare): ad-hoc item, still priced server-side.
-          lineItem.name = item.name
+          lineItem.name = item.name || 'Item'
         }
         return lineItem
       })
+
+      // Add shipping as a line item when delivery is selected
+      if (deliveryMethod === 'delivery' && shippingCents > 0) {
+        lineItems.push({
+          name: 'Shipping',
+          quantity: '1',
+          basePriceMoney: {
+            amount: BigInt(shippingCents),
+            currency: 'USD',
+          },
+        })
+      }
 
       const orderRequest = {
         idempotencyKey: crypto.randomUUID(),
@@ -508,7 +533,6 @@ export async function webHandler(request) {
           locationId: locationId,
           lineItems: lineItems,
           // Ensure Square computes taxes/discounts based on catalog + location settings.
-          // Without this, Square may not apply configured taxes automatically.
           pricingOptions: {
             autoApplyTaxes: true,
             autoApplyDiscounts: true,
@@ -522,20 +546,41 @@ export async function webHandler(request) {
         console.log('[Payment API] Linking order to Square customer:', squareCustomerId)
       }
 
-      // Add fulfillment info if pickup
+      // Fulfillment: SHIP with address when delivery, else PICKUP
       if (pickupForm) {
-        orderRequest.order.fulfillments = [{
-          type: 'PICKUP',
-          state: 'PROPOSED',
-          pickupDetails: {
-            recipient: {
-              displayName: `${pickupForm.firstName} ${pickupForm.lastName}`,
-              emailAddress: pickupForm.email,
-              phoneNumber: pickupForm.phone,
+        if (deliveryMethod === 'delivery' && pickupForm.address && pickupForm.city && pickupForm.state && pickupForm.zipCode) {
+          orderRequest.order.fulfillments = [{
+            type: 'SHIPMENT',
+            state: 'PROPOSED',
+            shipmentDetails: {
+              recipient: {
+                displayName: `${pickupForm.firstName || ''} ${pickupForm.lastName || ''}`.trim() || 'Customer',
+                emailAddress: pickupForm.email || undefined,
+                phoneNumber: pickupForm.phone || undefined,
+                address: {
+                  addressLine1: String(pickupForm.address || '').slice(0, 500),
+                  locality: String(pickupForm.city || '').slice(0, 255),
+                  administrativeDistrictLevel1: String(pickupForm.state || '').slice(0, 255),
+                  postalCode: String(pickupForm.zipCode || '').slice(0, 20),
+                  country: 'US',
+                },
+              },
             },
-            scheduleType: 'ASAP',
-          },
-        }]
+          }]
+        } else {
+          orderRequest.order.fulfillments = [{
+            type: 'PICKUP',
+            state: 'PROPOSED',
+            pickupDetails: {
+              recipient: {
+                displayName: `${pickupForm.firstName} ${pickupForm.lastName}`,
+                emailAddress: pickupForm.email,
+                phoneNumber: pickupForm.phone,
+              },
+              scheduleType: 'ASAP',
+            },
+          }]
+        }
       }
 
       console.log('[Payment API] Creating Square Order...')
@@ -640,14 +685,16 @@ export async function webHandler(request) {
           `INSERT INTO orders (
             id,
             customer_id,
-            order_number, 
-            square_order_id, 
-            square_payment_id, 
-            total_cents, 
-            status, 
+            order_number,
+            square_order_id,
+            square_payment_id,
+            total_cents,
+            status,
             pickup_details,
+            delivery_method,
+            shipping_cents,
             created_at
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())`,
           [
             dbOrderId,
             customerId,
@@ -655,8 +702,10 @@ export async function webHandler(request) {
             payment.orderId || orderId,
             payment.id,
             payment.amountMoney?.amount ? Number(payment.amountMoney.amount) : 0,
-            'PROPOSED', // New order just came in (canonical initial state)
-            JSON.stringify(pickupDetailsPayload)
+            'PROPOSED',
+            JSON.stringify(pickupDetailsPayload),
+            deliveryMethod,
+            shippingCents,
           ]
         )
 
@@ -707,6 +756,11 @@ export async function webHandler(request) {
         if (email) {
           try {
             const { sendEmail } = await import('./sendEmail.js')
+            const isDelivery = pickupForm?.deliveryMethod === 'delivery'
+            const pickupLocation = '215B Main Street, Milford, OH 45150'
+            const shippingAddressFormatted = isDelivery && (pickupForm?.address || pickupForm?.city)
+              ? [pickupForm.address, [pickupForm.city, pickupForm.state, pickupForm.zipCode].filter(Boolean).join(', ')].filter(Boolean).join(', ')
+              : null
             await sendEmail({
               type: 'order_confirmation',
               to: email,
@@ -721,13 +775,16 @@ export async function webHandler(request) {
                 customerName: `${pickupForm?.firstName || ''} ${pickupForm?.lastName || ''}`.trim(),
                 customerEmail: email,
                 customerPhone: pickupForm?.phone || null,
-                items: cartItems?.map(item => ({
-                  name: item.name,
-                  quantity: item.quantity,
-                  price: Number((item.priceCents || 0) / 100) || 0,
-                })) || [],
-                deliveryMethod: 'pickup',
-                pickupLocation: '215B Main Street, Milford, OH 45150',
+                items: Array.isArray(canonicalCartItems)
+                  ? canonicalCartItems.map((item) => ({
+                      name: item.name,
+                      quantity: item.quantity,
+                      price: Number((item.priceCents || 0) / 100) || 0,
+                    }))
+                  : [],
+                deliveryMethod: isDelivery ? 'delivery' : 'pickup',
+                pickupLocation: isDelivery ? null : pickupLocation,
+                shippingAddress: shippingAddressFormatted,
               },
               dedupeKey: `order_confirmation:${orderNumber}`,
             })
@@ -842,9 +899,13 @@ export async function webHandler(request) {
       const code = squareCode
       const detail = squareDetail
 
-      const friendlyByCode = (c) => {
+      const friendlyByCode = (c, d) => {
         if (!c) return null
         const codeStr = String(c).toUpperCase()
+        const detailStr = (d && String(d)) || ''
+        if (codeStr === 'NOT_FOUND' && (detailStr.includes('nonce') || detailStr.includes('Card'))) {
+          return 'Payment form expired or already used. Please re-enter your card details and try again.'
+        }
         if (codeStr.includes('CARD_DECLINED')) return 'Your card was declined. Please try another card.'
         if (codeStr.includes('VERIFY_CVV') || codeStr.includes('CVV')) return 'The card security code (CVV) looks incorrect. Please try again.'
         if (codeStr.includes('VERIFY_AVS') || codeStr.includes('AVS')) return 'The billing address could not be verified. Please check and try again.'
@@ -855,7 +916,7 @@ export async function webHandler(request) {
         return null
       }
 
-      const friendly = friendlyByCode(code)
+      const friendly = friendlyByCode(code, detail)
       if (friendly) {
         errorMessage = friendly
       } else if (detail) {

--- a/scripts/add-test-product.mjs
+++ b/scripts/add-test-product.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Insert a test product into the products table so it appears in the catalog.
+ * Then repopulates albums_cache so /api/products includes it.
+ *
+ * Usage: node scripts/add-test-product.mjs [square_variation_id]
+ * Default variation ID: GGPPKCPWHTPYJY3BTNHIBCGW
+ */
+
+import dotenv from 'dotenv'
+import { query } from '../api/db.js'
+import { populateAlbumsCache } from '../api/albumsCache.js'
+
+dotenv.config({ path: '.env.local' })
+dotenv.config()
+
+const VARIATION_ID = process.argv[2] || 'GGPPKCPWHTPYJY3BTNHIBCGW'
+
+async function main() {
+  console.log('Adding test product:', VARIATION_ID, '\n')
+
+  await query(`
+    INSERT INTO products (
+      square_variation_id,
+      square_item_id,
+      name,
+      variation_name,
+      description,
+      price_cents,
+      category,
+      reporting_category,
+      all_categories,
+      square_image_id,
+      stock_count,
+      updated_at,
+      created_at,
+      synced_at
+    ) VALUES (
+      $1,
+      $1,
+      'Test Product (Sandbox)',
+      'Default',
+      'Test product for checkout/sandbox.',
+      1999,
+      'New Vinyl',
+      NULL,
+      ARRAY['New Vinyl'],
+      NULL,
+      1,
+      NOW(),
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (square_variation_id) DO UPDATE SET
+      name = EXCLUDED.name,
+      variation_name = EXCLUDED.variation_name,
+      description = EXCLUDED.description,
+      price_cents = EXCLUDED.price_cents,
+      category = EXCLUDED.category,
+      all_categories = EXCLUDED.all_categories,
+      stock_count = EXCLUDED.stock_count,
+      updated_at = EXCLUDED.updated_at,
+      synced_at = EXCLUDED.synced_at
+  `, [VARIATION_ID])
+
+  console.log('✅ Product upserted into products table.\n')
+
+  console.log('Refreshing albums_cache...')
+  const result = await populateAlbumsCache()
+  console.log(`✅ Albums cache refreshed (${result.albumCount} albums, ${result.durationMs}ms).\n`)
+  console.log('Test product should now appear in the catalog (id: variation-' + VARIATION_ID + ')')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/delete-test-product.mjs
+++ b/scripts/delete-test-product.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Remove the test product from the products table and refresh albums_cache.
+ *
+ * Usage: node scripts/delete-test-product.mjs
+ */
+
+import dotenv from 'dotenv'
+import { query } from '../api/db.js'
+import { populateAlbumsCache } from '../api/albumsCache.js'
+
+dotenv.config({ path: '.env.local' })
+dotenv.config()
+
+const TEST_PRODUCT_NAME = 'Test Product (Sandbox)'
+const DEFAULT_VARIATION_ID = 'GGPPKCPWHTPYJY3BTNHIBCGW'
+
+async function main() {
+  console.log('Deleting test product...\n')
+
+  const r = await query(
+    `DELETE FROM products
+     WHERE name = $1 OR square_variation_id = $2
+     RETURNING square_variation_id, name`,
+    [TEST_PRODUCT_NAME, DEFAULT_VARIATION_ID]
+  )
+
+  const deletedProducts = r?.rowCount ?? 0
+  if (deletedProducts > 0) {
+    console.log(`✅ Deleted ${deletedProducts} row(s) from products (${(r.rows || []).map((row) => row.name || row.square_variation_id).join(', ')}).\n`)
+  } else {
+    console.log('No test product in products table.\n')
+  }
+
+  const ac = await query(
+    `DELETE FROM albums_cache
+     WHERE name = $1 OR square_variation_id = $2
+     RETURNING id, name`,
+    [TEST_PRODUCT_NAME, DEFAULT_VARIATION_ID]
+  )
+  const deletedCache = ac?.rowCount ?? 0
+  if (deletedCache > 0) {
+    console.log(`✅ Deleted ${deletedCache} row(s) from albums_cache.\n`)
+  }
+
+  // Rebuild albums_cache and products_api_cache so /api/products stops serving the test product.
+  // (products_api_cache and in-memory cache otherwise keep the old list.)
+  console.log('Refreshing albums_cache and products_api_cache...')
+  const result = await populateAlbumsCache()
+  console.log(`✅ Cache refreshed (${result.albumCount} albums, ${result.durationMs}ms).\n`)
+
+  console.log('Done. Restart the dev server (or wait ~30s) so in-memory products cache clears.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,0 +1,11 @@
+# Database migrations
+
+Run these against your Neon (or other Postgres) database when adding schema changes.
+
+## add-orders-shipping-columns.sql
+
+Adds `delivery_method` and `shipping_cents` to the `orders` table for shipping/delivery support.
+
+**When:** Before or after deploying the shipping feature; existing rows get defaults (`delivery_method = 'pickup'`, `shipping_cents = 0`).
+
+**How:** Execute the SQL in Neon’s SQL Editor (or `psql`), or use your usual migration runner.

--- a/scripts/migrations/add-orders-shipping-columns.sql
+++ b/scripts/migrations/add-orders-shipping-columns.sql
@@ -1,0 +1,13 @@
+-- Add delivery/shipping columns to orders for querying and reporting.
+-- Run once against your Neon (or other Postgres) database.
+-- Safe to re-run: uses IF NOT EXISTS (PostgreSQL 9.5+).
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS delivery_method TEXT DEFAULT 'pickup',
+  ADD COLUMN IF NOT EXISTS shipping_cents BIGINT DEFAULT 0;
+
+-- Optional: index for filtering delivery vs pickup (e.g. reports)
+CREATE INDEX IF NOT EXISTS idx_orders_delivery_method ON orders (delivery_method);
+
+COMMENT ON COLUMN orders.delivery_method IS 'pickup or delivery';
+COMMENT ON COLUMN orders.shipping_cents IS 'Shipping fee in cents when delivery_method = delivery';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -845,7 +845,11 @@ function App() {
       details?.orderId ||
       `#ORD-${Math.floor(Math.random() * 10000) + 2024}`;
 
-    // Generate Mock Order Object for Confirmation Page (if used)
+    const isDelivery = details.deliveryMethod === 'delivery';
+    const shippingAddressFormatted = isDelivery && (details.address || details.city)
+      ? [details.address, [details.city, details.state, details.zipCode].filter(Boolean).join(', ')].filter(Boolean).join(', ')
+      : undefined;
+
     const newOrder: Order = {
         id: effectiveOrderId,
         date: new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
@@ -859,8 +863,16 @@ function App() {
             format: item.product.format,
             price: item.product.salePrice || item.product.price
         })),
-        location: details.deliveryMethod === 'pickup' ? 'Milford Shop' : 'Shipping Address'
-    };
+        location: details.deliveryMethod === 'pickup' ? 'Milford Shop' : 'Shipping Address',
+        shipping: details.shipping != null ? details.shipping : (details.shippingCost ?? 0),
+        shippingAddress: shippingAddressFormatted,
+        deliveryMethod: details.deliveryMethod,
+        paymentMethod: details.paymentMethod,
+      };
+      if (details.deliveryMethod === 'delivery') {
+        newOrder.trackingNumber = details.trackingNumber;
+        newOrder.trackingUrl = details.trackingUrl;
+      }
 
     // Track purchase
     trackPurchase({

--- a/src/components/CartPage.tsx
+++ b/src/components/CartPage.tsx
@@ -190,6 +190,10 @@ export const CartPage: React.FC<CartPageProps> = ({
                                 <span className="opacity-70">Subtotal</span>
                                 <span>${subtotal.toFixed(2)}</span>
                             </div>
+                            <div className="flex justify-between text-xs opacity-60">
+                                <span>Shipping</span>
+                                <span>Calculated at checkout</span>
+                            </div>
                             <div className="flex justify-between">
                                 <span className="opacity-70">Estimated Tax</span>
                                 <span>${tax.toFixed(2)}</span>

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -63,7 +63,7 @@ const getBotResponse = (message: string): string => {
 
   // Returns/Refunds
   if (lowerMessage.includes('return') || lowerMessage.includes('refund') || lowerMessage.includes('exchange')) {
-    return `For returns or exchanges, please contact us at ${STORE_INFO.email} or call ${STORE_INFO.phone}. We're happy to help!`;
+    return `We offer 1 week returns from purchase. For returns or exchanges, contact us at ${STORE_INFO.email} or call ${STORE_INFO.phone}. We're happy to help!`;
   }
 
   // Events

--- a/src/components/CheckoutPage.tsx
+++ b/src/components/CheckoutPage.tsx
@@ -1,11 +1,13 @@
-
 import React, { useState, useEffect, useRef } from 'react';
 import { CartItem, ViewMode } from '../../types';
 import { Section } from './ui/Section';
 import { Button } from './ui/Button';
-import { ArrowLeft, Lock, CreditCard, Store, MapPin } from 'lucide-react';
+import { ArrowLeft, Lock, MapPin, Truck, Store } from 'lucide-react';
 import { loadSquareSdk } from '../utils/loadSquareSdk';
 import { initializeSquarePayments, generatePaymentToken, processPayment, SquarePayments, SquareCard } from '../services/squarePayment';
+import { siteConfig } from '../config';
+
+type DeliveryMethod = 'delivery' | 'pickup';
 
 interface CheckoutPageProps {
   cartItems: CartItem[];
@@ -21,6 +23,8 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
   onPlaceOrder
 }) => {
   const isRetro = viewMode === 'retro';
+  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>('pickup');
+  const [shippingAddress, setShippingAddress] = useState({ address: '', city: '', state: '', zipCode: '' });
   const [isProcessing, setIsProcessing] = useState(false);
   const [squarePayments, setSquarePayments] = useState<SquarePayments | null>(null);
   const [cardElement, setCardElement] = useState<SquareCard | null>(null);
@@ -231,21 +235,38 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
     const price = item.product.salePrice || item.product.price;
     return sum + (price * item.quantity);
   }, 0);
-  
-  const tax = subtotal * 0.07;
-  const total = subtotal + tax;
+
+  // Match backend calculation: fixed fee unless order meets free-shipping threshold
+  const shippingFee =
+    deliveryMethod === 'delivery'
+      ? (siteConfig.freeShippingThreshold > 0 && subtotal >= siteConfig.freeShippingThreshold ? 0 : siteConfig.shippingFee)
+      : 0;
+  const tax = (subtotal + shippingFee) * 0.07;
+  const total = subtotal + shippingFee + tax;
+  const shippingCents = Math.round(shippingFee * 100);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setIsProcessing(true);
-    
+
     try {
         if (isCartEmpty || total <= 0) {
             throw new Error('Add items to your cart before checking out.');
         }
         if (!cardElement) {
             throw new Error('Payment form not ready');
+        }
+        if (deliveryMethod === 'delivery') {
+            const { address, city, state, zipCode } = shippingAddress;
+            if (!address?.trim() || !city?.trim() || !state?.trim() || !zipCode?.trim()) {
+                throw new Error('Please enter your full shipping address.');
+            }
+            // Domestic (US) only: ZIP must be 5 digits or ZIP+4
+            const usZip = /^\d{5}(-\d{4})?$/.test(String(zipCode).trim());
+            if (!usZip) {
+                throw new Error('Domestic (US) shipping only. Please enter a valid US ZIP code (e.g. 45150 or 45150-1234).');
+            }
         }
 
         // 1. Get Token from Square
@@ -265,19 +286,27 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
         const phone = (formData.get('phone') as string) || '';
         const newsletterOptIn = Boolean(formData.get('newsletterOptIn'));
 
-        const pickupForm = {
+        const pickupForm: Record<string, unknown> = {
             firstName,
             lastName,
             email,
-            phone
+            phone,
+            deliveryMethod,
         };
+        if (deliveryMethod === 'delivery') {
+            pickupForm.address = shippingAddress.address;
+            pickupForm.city = shippingAddress.city;
+            pickupForm.state = shippingAddress.state;
+            pickupForm.zipCode = shippingAddress.zipCode;
+        }
 
-        // 3. Process Payment on Backend
+        // 3. Process Payment on Backend (amount from Square order = subtotal + tax + shipping when delivery)
         const result = await processPayment(
             tokenResult.token,
-            Math.round(total * 100), // Amount in cents
+            Math.round(total * 100),
             {
                 pickupForm,
+                shippingCents,
                 cartItems: cartItems.map(item => ({
                     id: item.product.id,
                     name: item.product.title,
@@ -316,12 +345,14 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
 
             onPlaceOrder({
                 ...pickupForm,
-                deliveryMethod: 'pickup',
+                email,
+                deliveryMethod,
                 subtotal: finalSubtotal,
                 tax: finalTax,
                 total: finalTotal,
-                shippingCost: 0,
-                orderNumber: result.orderId // Pass back the real order ID/Number
+                shipping: shippingFee,
+                shippingCost: shippingFee,
+                orderNumber: result.orderId
             });
         } else {
             throw new Error(result.error || 'Payment failed');
@@ -447,7 +478,7 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
                            </div>
                        </div>
 
-                       {/* 2. Delivery Method */}
+                       {/* 2. Delivery or Pickup */}
                        <div className={`p-6 md:p-8 relative
                            ${isRetro 
                             ? 'bg-white border-2 border-brand-black shadow-retro' 
@@ -457,19 +488,110 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
                                <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm border-2
                                    ${isRetro ? 'bg-brand-black text-white border-brand-black' : 'bg-black text-white border-black'}
                                `}>2</span>
-                               Pickup Details
+                               Delivery or Pickup
                            </h2>
-                           
-                           <div className={`p-4 text-sm flex items-start gap-3
-                               ${isRetro ? 'bg-brand-teal/10 border-2 border-brand-teal' : 'bg-gray-50 rounded-lg border border-gray-200'}
-                           `}>
-                               <MapPin className="text-brand-teal flex-shrink-0" size={20} />
-                               <div>
-                                   <p className="font-bold mb-1">Pickup Location:</p>
-                                   <p>215B Main Street, Milford, OH, United States, 45150</p>
-                                   <p className="mt-2 text-xs opacity-70">Bring your ID and order confirmation when you arrive.</p>
-                               </div>
+
+                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+                               <button
+                                 type="button"
+                                 onClick={() => setDeliveryMethod('delivery')}
+                                 className={`p-4 text-left rounded-xl border-2 transition flex items-start gap-3
+                                   ${deliveryMethod === 'delivery'
+                                     ? isRetro ? 'border-brand-black bg-brand-teal/10' : 'border-black bg-gray-50'
+                                     : isRetro ? 'border-brand-black/30 hover:border-brand-teal' : 'border-gray-200 hover:border-gray-300'}
+                                 `}
+                               >
+                                 <Truck className={deliveryMethod === 'delivery' ? 'text-brand-teal' : 'text-gray-400'} size={24} />
+                                 <div>
+                                   <p className="font-bold">Delivery</p>
+                                   <p className="text-sm opacity-70">
+                                   {siteConfig.freeShippingThreshold > 0
+                                     ? `Ship to my address ($${siteConfig.shippingFee.toFixed(2)} or free over $${siteConfig.freeShippingThreshold.toFixed(0)})`
+                                     : `Ship to my address ($${siteConfig.shippingFee.toFixed(2)} shipping)`}
+                                 </p>
+                                 </div>
+                               </button>
+                               <button
+                                 type="button"
+                                 onClick={() => setDeliveryMethod('pickup')}
+                                 className={`p-4 text-left rounded-xl border-2 transition flex items-start gap-3
+                                   ${deliveryMethod === 'pickup'
+                                     ? isRetro ? 'border-brand-black bg-brand-teal/10' : 'border-black bg-gray-50'
+                                     : isRetro ? 'border-brand-black/30 hover:border-brand-teal' : 'border-gray-200 hover:border-gray-300'}
+                                 `}
+                               >
+                                 <Store className={deliveryMethod === 'pickup' ? 'text-brand-teal' : 'text-gray-400'} size={24} />
+                                 <div>
+                                   <p className="font-bold">Pickup</p>
+                                   <p className="text-sm opacity-70">Pick up at the shop (free)</p>
+                                 </div>
+                               </button>
                            </div>
+
+                           {deliveryMethod === 'pickup' && (
+                             <div className={`p-4 text-sm flex items-start gap-3
+                                 ${isRetro ? 'bg-brand-teal/10 border-2 border-brand-teal' : 'bg-gray-50 rounded-lg border border-gray-200'}
+                             `}>
+                                 <MapPin className="text-brand-teal flex-shrink-0" size={20} />
+                                 <div>
+                                     <p className="font-bold mb-1">Pickup Location</p>
+                                     <p>{siteConfig.contact.location}</p>
+                                     <p className="mt-2 text-xs opacity-70">Bring your ID and order confirmation when you arrive.</p>
+                                 </div>
+                             </div>
+                           )}
+
+                           {deliveryMethod === 'delivery' && (
+                             <div className="space-y-4">
+                               <p className="text-sm opacity-70">Domestic (US) shipping only. Material &amp; media shipping.</p>
+                               <input
+                                 name="address"
+                                 type="text"
+                                 placeholder="Street address"
+                                 required={deliveryMethod === 'delivery'}
+                                 value={shippingAddress.address}
+                                 onChange={(e) => setShippingAddress(prev => ({ ...prev, address: e.target.value }))}
+                                 className={`w-full p-4 font-medium focus:outline-none transition-all
+                                     ${isRetro ? 'bg-brand-cream border-2 border-brand-black focus:shadow-pop-sm placeholder-brand-black/30' : 'bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:border-black focus:ring-1 focus:ring-black'}
+                                 `}
+                               />
+                               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                 <input
+                                   name="city"
+                                   type="text"
+                                   placeholder="City"
+                                   required={deliveryMethod === 'delivery'}
+                                   value={shippingAddress.city}
+                                   onChange={(e) => setShippingAddress(prev => ({ ...prev, city: e.target.value }))}
+                                   className={`w-full p-4 font-medium focus:outline-none transition-all sm:col-span-2
+                                       ${isRetro ? 'bg-brand-cream border-2 border-brand-black focus:shadow-pop-sm placeholder-brand-black/30' : 'bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:border-black focus:ring-1 focus:ring-black'}
+                                   `}
+                                 />
+                                 <input
+                                   name="state"
+                                   type="text"
+                                   placeholder="State"
+                                   required={deliveryMethod === 'delivery'}
+                                   value={shippingAddress.state}
+                                   onChange={(e) => setShippingAddress(prev => ({ ...prev, state: e.target.value }))}
+                                   className={`w-full p-4 font-medium focus:outline-none transition-all
+                                       ${isRetro ? 'bg-brand-cream border-2 border-brand-black focus:shadow-pop-sm placeholder-brand-black/30' : 'bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:border-black focus:ring-1 focus:ring-black'}
+                                   `}
+                                 />
+                               </div>
+                               <input
+                                 name="zipCode"
+                                 type="text"
+                                 placeholder="ZIP code"
+                                 required={deliveryMethod === 'delivery'}
+                                 value={shippingAddress.zipCode}
+                                 onChange={(e) => setShippingAddress(prev => ({ ...prev, zipCode: e.target.value }))}
+                                 className={`w-full p-4 font-medium focus:outline-none transition-all max-w-[140px]
+                                     ${isRetro ? 'bg-brand-cream border-2 border-brand-black focus:shadow-pop-sm placeholder-brand-black/30' : 'bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:border-black focus:ring-1 focus:ring-black'}
+                                 `}
+                               />
+                             </div>
+                           )}
                        </div>
 
                        {/* 3. Payment */}
@@ -558,6 +680,12 @@ export const CheckoutPage: React.FC<CheckoutPageProps> = ({
                                 <span className="opacity-70">Subtotal</span>
                                 <span>${subtotal.toFixed(2)}</span>
                             </div>
+                            {deliveryMethod === 'delivery' && (
+                              <div className="flex justify-between">
+                                <span className="opacity-70">Shipping</span>
+                                <span>${shippingFee.toFixed(2)}</span>
+                              </div>
+                            )}
                             <div className="flex justify-between">
                                 <span className="opacity-70">Estimated Tax</span>
                                 <span>${tax.toFixed(2)}</span>

--- a/src/components/LocationsPage.tsx
+++ b/src/components/LocationsPage.tsx
@@ -88,19 +88,11 @@ export const LocationsPage: React.FC<LocationsPageProps> = ({ viewMode }) => {
                       <ul className="space-y-3 text-sm text-gray-600">
                          <li className="flex items-start gap-2">
                             <span className="font-bold text-brand-black">•</span>
-                            <span><strong>Vintage Vinyl:</strong> 48 hours after purchase.</span>
+                            <span><strong>1 week returns</strong> from date of purchase.</span>
                          </li>
                          <li className="flex items-start gap-2">
                             <span className="font-bold text-brand-black">•</span>
-                            <span><strong>New Vinyl:</strong> 30 days — sealed exchange for full value; if opened, 50% value returned.</span>
-                         </li>
-                         <li className="flex items-start gap-2">
-                            <span className="font-bold text-brand-black">•</span>
-                            <span><strong>Equipment:</strong> sealed, still in box — $15 restocking fee on return.</span>
-                         </li>
-                         <li className="flex items-start gap-2">
-                            <span className="font-bold text-brand-black">•</span>
-                            <span>$5 restocking fee on all new returns.</span>
+                            <span>Contact us for exchanges or refunds.</span>
                          </li>
                          <li className="flex items-start gap-2">
                             <span className="font-bold text-brand-black">•</span>

--- a/src/components/OrderConfirmationPage.tsx
+++ b/src/components/OrderConfirmationPage.tsx
@@ -64,6 +64,9 @@ export const OrderConfirmationPage: React.FC<OrderConfirmationPageProps> = ({ or
                     <div>
                          <span className="block text-xs font-bold uppercase tracking-widest text-gray-400 mb-1">Total Paid</span>
                          <span className="font-header font-extrabold tabular-nums text-2xl">${order.total.toFixed(2)}</span>
+                         {(order.shipping ?? 0) > 0 && (
+                           <p className="text-xs text-gray-500 mt-1">Includes ${order.shipping!.toFixed(2)} shipping</p>
+                         )}
                     </div>
                     <div>
                          <span className="block text-xs font-bold uppercase tracking-widest text-gray-400 mb-1">Date</span>
@@ -88,7 +91,7 @@ export const OrderConfirmationPage: React.FC<OrderConfirmationPageProps> = ({ or
                             ) : (
                                 <>
                                    <p className="font-bold text-black mb-1">Shipping Address</p>
-                                   <p>{order.location}</p>
+                                   <p>{order.shippingAddress || order.location}</p>
                                    <p className="mt-2 text-xs text-gray-400">Via USPS Media Mail</p>
                                 </>
                             )}

--- a/src/components/OrderStatusPage.tsx
+++ b/src/components/OrderStatusPage.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { ViewMode, Page, Order } from '../../types';
 import { Section } from './ui/Section';
 import { Button } from './ui/Button';
-import { Search, Package, Loader2, CheckCircle2, AlertCircle, MapPin, Clock } from 'lucide-react';
+import { Search, Package, Loader2, CheckCircle2, AlertCircle, MapPin, Clock, Truck, ExternalLink } from 'lucide-react';
 import { mapOrderStatus } from '../utils/orderStatus';
 
 interface OrderStatusPageProps {
@@ -75,21 +75,33 @@ export const OrderStatusPage: React.FC<OrderStatusPageProps> = ({
             if (onPersistLookup && (resolvedOrderNumber || resolvedEmail)) {
               onPersistLookup({ id: resolvedOrderNumber, email: resolvedEmail });
             }
+            const pickupDetails = apiOrder.pickup_details || {};
+            const hasShippingAddress = !!(pickupDetails.address && (pickupDetails.city || pickupDetails.zipCode));
+            const isDelivery =
+              (pickupDetails.deliveryMethod === 'delivery') ||
+              (apiOrder.delivery_method === 'delivery') ||
+              (hasShippingAddress && pickupDetails.deliveryMethod !== 'pickup' && apiOrder.delivery_method !== 'pickup');
+            const shippingAddressFormatted = isDelivery && (pickupDetails.address || pickupDetails.city)
+              ? [pickupDetails.address, [pickupDetails.city, pickupDetails.state, pickupDetails.zipCode].filter(Boolean).join(', ')].filter(Boolean).join(', ')
+              : undefined;
             const uiOrder: Order = {
                 id: apiOrder.order_number || apiOrder.id,
                 date: new Date(apiOrder.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-                // Store the canonical DB status so the UI can reflect it accurately (PROPOSED/RESERVED/PREPARED/COMPLETED/CANCELED).
                 status: normalizedDbStatus || mapOrderStatus(apiOrder.status),
                 total: apiOrder.total_cents / 100,
-                subtotal: apiOrder.total_cents / 100, // API might not return subtotal separate yet, using total for now
-                tax: 0, // Calculated on frontend or needs to be stored
+                subtotal: apiOrder.total_cents / 100,
+                tax: 0,
                 items: apiItems.map((item: any) => ({
                     title: item.name,
-                    artist: 'Unknown', // Backend might not store artist for ad-hoc items
+                    artist: 'Unknown',
                     format: item.quantity && Number(item.quantity) > 1 ? `x${Number(item.quantity)}` : 'LP',
                     price: Number(item.price) || 0,
                 })),
-                location: 'Milford Shop'
+                location: isDelivery ? 'Shipping' : 'Milford Shop',
+                deliveryMethod: isDelivery ? 'delivery' : 'pickup',
+                shippingAddress: shippingAddressFormatted,
+                trackingNumber: pickupDetails.trackingNumber || undefined,
+                trackingUrl: pickupDetails.trackingUrl || undefined,
             };
             setResult(uiOrder);
         } else {
@@ -217,6 +229,9 @@ export const OrderStatusPage: React.FC<OrderStatusPageProps> = ({
 
                         const stepActive = (idx: number) => !isCanceled && progressIndex >= idx;
                         const barWidth = isCanceled ? 0 : `${(progressIndex / 3) * 100}%`;
+                        const isDeliveryOrder = result.deliveryMethod === 'delivery';
+                        const lastStepLabel = isDeliveryOrder ? 'Delivered' : 'Picked Up';
+                        const thirdStepLabel = isDeliveryOrder ? 'Shipped' : 'Ready';
 
                         return (
                           <>
@@ -258,13 +273,13 @@ export const OrderStatusPage: React.FC<OrderStatusPageProps> = ({
                                 <div className={`w-8 h-8 rounded-full flex items-center justify-center border-2 border-white shadow-sm ${stepActive(2) ? 'bg-brand-teal text-white' : 'bg-gray-200 text-gray-400'}`}>
                                   <CheckCircle2 size={16} />
                                 </div>
-                                <span className={`text-[10px] font-bold uppercase tracking-wider ${stepActive(2) ? '' : 'text-gray-400'}`}>Ready</span>
+                                <span className={`text-[10px] font-bold uppercase tracking-wider ${stepActive(2) ? '' : 'text-gray-400'}`}>{thirdStepLabel}</span>
                             </div>
                             <div className="flex flex-col items-center gap-2">
                                 <div className={`w-8 h-8 rounded-full flex items-center justify-center border-2 border-white shadow-sm ${stepActive(3) ? 'bg-brand-teal text-white' : 'bg-gray-200 text-gray-400'}`}>
                                   <CheckCircle2 size={16} />
                                 </div>
-                                <span className={`text-[10px] font-bold uppercase tracking-wider ${stepActive(3) ? '' : 'text-gray-400'}`}>Picked Up</span>
+                                <span className={`text-[10px] font-bold uppercase tracking-wider ${stepActive(3) ? '' : 'text-gray-400'}`}>{lastStepLabel}</span>
                             </div>
                         </div>
                     </div>
@@ -284,6 +299,46 @@ export const OrderStatusPage: React.FC<OrderStatusPageProps> = ({
                                 ))}
                             </ul>
                         </div>
+                        {result.deliveryMethod === 'delivery' ? (
+                          <div className="space-y-6">
+                            <div>
+                              <h4 className="font-bold text-sm uppercase tracking-widest mb-4 opacity-60">Shipping Address</h4>
+                              <div className="flex items-start gap-3">
+                                <Truck className="text-brand-teal flex-shrink-0" size={20} />
+                                <div>
+                                  <p className="text-sm font-medium">{result.shippingAddress || 'Address on file'}</p>
+                                </div>
+                              </div>
+                            </div>
+                            <div>
+                              <h4 className="font-bold text-sm uppercase tracking-widest mb-4 opacity-60">Tracking</h4>
+                              <div className="flex items-start gap-3">
+                                <Package className="text-brand-orange flex-shrink-0" size={20} />
+                                <div className="min-w-0">
+                                  {result.trackingNumber || result.trackingUrl ? (
+                                    <>
+                                      {result.trackingNumber && (
+                                        <p className="text-sm font-mono font-medium break-all">{result.trackingNumber}</p>
+                                      )}
+                                      {result.trackingUrl && (
+                                        <a
+                                          href={result.trackingUrl}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          className="inline-flex items-center gap-1 text-sm font-bold text-brand-orange hover:underline mt-1"
+                                        >
+                                          Track package <ExternalLink size={14} />
+                                        </a>
+                                      )}
+                                    </>
+                                  ) : (
+                                    <p className="text-sm text-gray-500">We&apos;ll email you tracking when your order ships.</p>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        ) : (
                         <div>
                              <h4 className="font-bold text-sm uppercase tracking-widest mb-4 opacity-60">Pickup Location</h4>
                              <div className="flex items-start gap-3">
@@ -296,6 +351,7 @@ export const OrderStatusPage: React.FC<OrderStatusPageProps> = ({
                                 </div>
                              </div>
                         </div>
+                        )}
                     </div>
 
                     <div className="text-center">

--- a/src/components/ReceiptPage.tsx
+++ b/src/components/ReceiptPage.tsx
@@ -149,7 +149,7 @@ export const ReceiptPage: React.FC<ReceiptPageProps> = ({ order, viewMode, onBac
                     <p>215B Main Street</p>
                     <p>Milford, OH 45150</p>
                     <p>(513) 600-8018</p>
-                    <p>www.spiralgroove.com</p>
+                    <p>www.spiralgrooverecords.com</p>
                  </div>
               </div>
 
@@ -206,7 +206,7 @@ export const ReceiptPage: React.FC<ReceiptPageProps> = ({ order, viewMode, onBac
               <div className="text-center space-y-6 relative z-10">
                  <div className="space-y-2">
                     <p className="font-bold uppercase text-sm">Thank You for Digging!</p>
-                    <p className="text-xs opacity-70">Return Policy: Vintage Vinyl 48 hours. New Vinyl 30 days (sealed exchange; opened 50% value). Equipment sealed in box: $15 restocking fee. $5 restocking fee on all new returns.</p>
+                    <p className="text-xs opacity-70">Return Policy: 1 week from purchase. Contact us for exchanges or refunds.</p>
                  </div>
                  
                  {/* Fake Barcode */}

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,10 @@ export type SiteConfig = {
     location: string
     hours: string
   }
+  /** Fixed shipping fee in USD when delivery is selected (MVP). */
+  shippingFee: number
+  /** Order subtotal in USD at or above which shipping is free (0 = no free shipping). */
+  freeShippingThreshold: number
   legal: {
     privacyUrl: string
     termsUrl: string
@@ -108,6 +112,8 @@ export const siteConfig: SiteConfig = {
     location: '215B Main Street, Milford, OH 45150',
     hours: 'Mon–Thu 12pm–8pm · Fri & Sat 12pm–9pm · Sun 12pm–5pm',
   },
+  shippingFee: Number(import.meta.env.VITE_SHIPPING_FEE ?? '10') || 10,
+  freeShippingThreshold: Number(import.meta.env.VITE_FREE_SHIPPING_THRESHOLD ?? '0') || 0,
   legal: {
     privacyUrl: 'https://www.spiralgrooverecords.com/privacy',
     termsUrl: 'https://www.spiralgrooverecords.com/terms',

--- a/types.ts
+++ b/types.ts
@@ -81,6 +81,18 @@ export interface Order {
   location: string;
   subtotal: number;
   tax: number;
+  /** Shipping cost in USD when delivery was selected */
+  shipping?: number;
+  /** Formatted shipping address when delivery was selected */
+  shippingAddress?: string;
+  /** Whether order is pickup or delivery */
+  deliveryMethod?: 'pickup' | 'delivery';
+  /** Carrier tracking number when shipped (delivery orders) */
+  trackingNumber?: string;
+  /** Link to carrier tracking page (delivery orders) */
+  trackingUrl?: string;
+  /** Payment method used for the order */
+  paymentMethod?: string;
 }
 
 export type ViewMode = 'retro' | 'modern';


### PR DESCRIPTION
- Shipping:  default, domestic (US) only; ZIP validation (5-digit or ZIP+4)
- Returns: 1 week policy (Receipt, Locations, Chatbot)
- Order-status: delivery_method from API + infer from address; show Shipping vs Pickup
- Orders API: delivery_method column, normalize pickup_details.deliveryMethod
- Migrations: add-orders-shipping-columns.sql; scripts add/delete-test-product.mjs
- Product images: set name/imageUrl on mapped products; Product type optional name/imageUrl
- .env.example: shipping 10, domestic-only notes

Made-with: Cursor